### PR TITLE
Jira link template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-_(Don't forget to put the JIRA # e.g. HSND-123 in the PR title and branch name)_
+https://homeservenow.atlassian.net/browse/[JIRA-TICKET-ID]
 
 ## Brief description of what's changing
 - [ ] Added thing 1


### PR DESCRIPTION
_(Don't forget to put ... what was it? Meh TL;DR)_

## Brief description of what's changing
- Use Jira link, expecting the user to fill in the ticket number only

## Brief description of why it's changed
Lazy developers don't update that Jira link